### PR TITLE
Add bash aliases for ros_packages management

### DIFF
--- a/ansible/drones_update.yml
+++ b/ansible/drones_update.yml
@@ -82,3 +82,26 @@
       args:
         chdir: "{{ drone_ros_path }}"
     
+    - name: Configure ros_packages bash helpers
+      block:
+        - name: Ensure ~/.bash_aliases file exists
+          ansible.builtin.file:
+            path: "~/.bash_aliases"
+            state: touch
+            mode: '0644'
+
+        - name: Add ros_packages helper aliases
+          ansible.builtin.blockinfile:
+            path: "~/.bash_aliases"
+            marker: "# {mark} ANSIBLE MANAGED ROS_PACKAGES HELPERS"
+            block: |
+              # Convenience helpers for managing the ros_packages user service
+              # Usage:
+              #   rosctl <status|restart|start|stop> [additional systemctl options]
+              #   roslogs [additional journalctl options]
+              function rosctl() {
+                  systemctl --user "$@" ros_packages
+              }
+
+              alias roslogs='journalctl --user -u ros_packages'
+    

--- a/ansible/drones_update.yml
+++ b/ansible/drones_update.yml
@@ -15,6 +15,29 @@
       path: "{{ drone_ros_path }}/src"
       state: directory
 
+  - name: Configure ros_packages bash helpers
+    block:
+      - name: Ensure ~/.bash_aliases file exists
+        ansible.builtin.file:
+          path: "~/.bash_aliases"
+          state: touch
+          mode: '0644'
+
+      - name: Add ros_packages helper aliases
+        ansible.builtin.blockinfile:
+          path: "~/.bash_aliases"
+          marker: "# {mark} ANSIBLE MANAGED ROS_PACKAGES HELPERS"
+          block: |
+            # Convenience helpers for managing the ros_packages user service
+            # Usage:
+            #   rosctl <status|restart|start|stop> [additional systemctl options]
+            #   roslogs [additional journalctl options]
+            function rosctl() {
+                systemctl --user "$@" ros_packages
+            }
+
+            alias roslogs='journalctl --user -u ros_packages'
+
   - name: Optitrack
     when: "position_estimation == 'optitrack'"
     block: 
@@ -81,27 +104,4 @@
       ansible.builtin.shell: . /opt/ros/humble/setup.sh && colcon build --symlink-install 
       args:
         chdir: "{{ drone_ros_path }}"
-    
-    - name: Configure ros_packages bash helpers
-      block:
-        - name: Ensure ~/.bash_aliases file exists
-          ansible.builtin.file:
-            path: "~/.bash_aliases"
-            state: touch
-            mode: '0644'
-
-        - name: Add ros_packages helper aliases
-          ansible.builtin.blockinfile:
-            path: "~/.bash_aliases"
-            marker: "# {mark} ANSIBLE MANAGED ROS_PACKAGES HELPERS"
-            block: |
-              # Convenience helpers for managing the ros_packages user service
-              # Usage:
-              #   rosctl <status|restart|start|stop> [additional systemctl options]
-              #   roslogs [additional journalctl options]
-              function rosctl() {
-                  systemctl --user "$@" ros_packages
-              }
-
-              alias roslogs='journalctl --user -u ros_packages'
     


### PR DESCRIPTION
Add `rosctl` and `roslogs` bash helpers to drones for managing the `ros_packages` systemd service.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e6113f6-e858-4f13-a782-41376c49fed1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e6113f6-e858-4f13-a782-41376c49fed1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

