### PR TITLE
Investigate optitrack_wrapper graceful shutdown

### DIFF
--- a/ansible/scripts/ros_packages_start.sh
+++ b/ansible/scripts/ros_packages_start.sh
@@ -11,4 +11,4 @@ source /opt/ros/humble/setup.bash
 source install/setup.bash
 
 
-ros2 launch {{ base_path }}/launch.py 
+exec ros2 launch {{ base_path }}/launch.py 

--- a/ansible/templates/ros_packages_service.j2
+++ b/ansible/templates/ros_packages_service.j2
@@ -7,8 +7,6 @@ Type=simple
 ExecStart=/bin/bash {{ base_path }}/ros_packages_start.sh
 KillSignal=SIGINT
 KillMode=control-group
-TimeoutStopSec=15
-Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/templates/ros_packages_service.j2
+++ b/ansible/templates/ros_packages_service.j2
@@ -5,6 +5,10 @@ After=multi-user.target
 [Service]
 Type=simple
 ExecStart=/bin/bash {{ base_path }}/ros_packages_start.sh
+KillSignal=SIGINT
+KillMode=control-group
+TimeoutStopSec=15
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Modify systemd service and startup script to enable graceful ROS 2 node termination.

Systemd's default SIGTERM to a shell wrapper did not reliably propagate to ROS 2 nodes, which expect SIGINT for graceful shutdown. This led to nodes hanging and eventually being SIGKILLed. The changes ensure SIGINT is sent directly to the ROS 2 launch process and its children, allowing for proper shutdown.

---
<a href="https://cursor.com/background-agent?bcId=bc-134ae3c5-79df-40b1-ae67-0254f57a9385">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-134ae3c5-79df-40b1-ae67-0254f57a9385">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

